### PR TITLE
Re-add TLS tracker

### DIFF
--- a/backgroundTasks.go
+++ b/backgroundTasks.go
@@ -243,3 +243,110 @@ func detectNameserverChanges() {
 		log.Printf("Failed to send nameserver change alert email: %v\n", err)
 	}
 }
+
+func updateTLSCerts() {
+	db := setupDatabase()
+	defer db.Close(context.Background())
+	// Get all certificates
+	rows, err := db.Query(context.TODO(), "SELECT * FROM crts")
+	if err != nil {
+		log.Printf("Failed to get certificates: %v\n", err)
+		return
+	}
+	defer rows.Close()
+
+	// Collect rows into a slice of Domain structs
+	domains, err := pgx.CollectRows(rows, pgx.RowToStructByName[TLSDomain])
+	if err != nil {
+		log.Printf("Failed to collect certificates: %v\n", err)
+		return
+	}
+
+	// Iterate over each certificate and check expiration
+	for _, d := range domains {
+		log.Printf("Refreshing certificate: %s\n", d.Domain)
+		commonName, validTo, issuer, rawData, err := getTLSCert(d.Domain)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		_, err = db.Exec(context.TODO(), "UPDATE crts SET expiration = $1, authority = $2, rawData = $3, commonName = $4 WHERE id = $5",
+			validTo, issuer, rawData, commonName, d.ID)
+		if err != nil {
+			log.Printf("Failed to update certificate %s: %v\n", d.Domain, err)
+			continue
+		}
+
+		// TSK: consider for removal
+		log.Printf("Updated certificate: %s\n", d.Domain)
+		time.Sleep(5 * time.Second) // to avoid rate limiting
+	}
+}
+
+func sendTLSExpirationReminders() {
+	db := setupDatabase()
+	defer db.Close(context.Background())
+	// Get all certificates
+	rows, err := db.Query(context.TODO(), "SELECT * FROM crts")
+	if err != nil {
+		log.Printf("Failed to get certificates: %v\n", err)
+		return
+	}
+	defer rows.Close()
+
+	certs, err := pgx.CollectRows(rows, pgx.RowToStructByName[TLSDomain])
+	if err != nil {
+		log.Printf("Failed to collect certificates: %v\n", err)
+		return
+	}
+	// Array to hold certificates needing reminders
+	var needReminder []TLSDomain
+
+	// Populate the array
+	for _, d := range certs {
+		currTime := time.Now().AddDate(0, 0, getConfig().DaysCertExp)
+
+		// Check if the certificate expires within the configured reminder period
+		if currTime.After(d.Expiration) {
+			needReminder = append(needReminder, d)
+		}
+	}
+
+	log.Printf("Sending expiration reminder for %d certificates", len(needReminder))
+
+	var domainList string
+
+	if len(needReminder) == 0 {
+		log.Println("No domains need reminders, skipping email.")
+		return
+	} else {
+		for _, d := range needReminder {
+			// add to the list
+			domainList += fmt.Sprintf("<li><a href='%s/dash/tls/?q=%s'>%s</a> is expiring on %s UTC (in %s)</li>", getConfig().BaseURL, d.CommonName, d.CommonName, d.Expiration.Format("01/02/2006 @ 03:04:05PM"), humanize.Time(d.Expiration))
+		}
+	}
+
+	err = sendEmail("Domains expiring soon", fmt.Sprintf(`
+		<!DOCTYPE html>
+		<html>
+			<head>
+  				<meta charset="UTF-8">
+  				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+  			</head>
+			<body>
+				<h3>The following TLS certificate(s) are expiring within the next %d days:</h3>
+				<p>Click a domain to view it in TLS certificate Tracker</p>
+				<ul>
+					%s
+				</ul>
+				<br />
+				<footer style='font-size: smaller;'>
+					Powered by <img src='https://assets.cdn.utsav2.dev:453/bucket/domaintrk/favicon.webp' style='width: 20px; border-radius: 50%%;' />Domain Tracker for <img src='https://cbt.io/wp-content/uploads/2023/07/favicon.png' style='width: 20px;' />California Business Technology<sup>®</sup> Inc.
+				</footer>
+			</body>
+		</html>`, getConfig().DaysCertExp, domainList))
+	if err != nil {
+		log.Printf("TLS: Failed to send expiration reminder email: %v\n", err)
+	}
+}

--- a/backgroundTasks.go
+++ b/backgroundTasks.go
@@ -327,7 +327,7 @@ func sendTLSExpirationReminders() {
 		}
 	}
 
-	err = sendEmail("Domains expiring soon", fmt.Sprintf(`
+	err = sendEmail("TLS certificates soon", fmt.Sprintf(`
 		<!DOCTYPE html>
 		<html>
 			<head>

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
 	"initPassword": "example123",
 	"listenAddr": "0.0.0.0:8746",
 	"remindDomainExpDays": 25,
+	"remindCertExpDays": 15,
 	"to_email": "exp@example.com",
 	"from_email": "domaintrk@example.com",
 	"smtp_host": "smtp.example.org",

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -410,6 +411,159 @@ func manRefHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// Allow adding domain to track TLS certs
+func tlsAddHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check session token
+	userID, err := checkSessionToken(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	} else if userID != 1 {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Decode the JSON request body
+	var domain DomainReqBody
+	if err := json.NewDecoder(r.Body).Decode(&domain); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		log.Println(err)
+		return
+	}
+	// Make sure the required fields are present
+	if domain.ClientID == 0 || domain.Domain == "" {
+		http.Error(w, "Missing required fields", http.StatusBadRequest)
+		return
+	}
+
+	// Connect to the server of the domain on port 443 and get the TLS certificate
+	conn, err := tls.Dial("tcp", domain.Domain+":443", nil)
+	if err != nil {
+		http.Error(w, "Failed to connect to domain on port 443", http.StatusInternalServerError)
+		log.Println(err)
+		return
+	}
+	defer conn.Close()
+
+	// Get the certificate
+	cert := conn.ConnectionState().PeerCertificates[0]
+	certJSON, err := json.Marshal(cert)
+	if err != nil {
+		http.Error(w, "Failed to marshal certificate", http.StatusInternalServerError)
+		log.Println(err)
+		return
+	}
+
+	db := setupDatabase()
+	defer db.Close(context.Background())
+	// Insert the new domain into the DB
+	_, err = db.Exec(context.TODO(), "INSERT INTO crts (domain, commonName, expiration, authority, clientId, rawData, notes) VALUES ($1, $2, $3, $4, $5, $6, $7);",
+		domain.Domain,
+		cert.Subject.CommonName,
+		cert.NotAfter,
+		cert.Issuer.Organization[0],
+		domain.ClientID,
+		certJSON,
+		domain.Notes,
+	)
+	if err != nil {
+		log.Print(err)
+		http.Error(w, "Failed to add domain", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func tlsListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check session token
+	userID, err := checkSessionToken(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	} else if userID != 1 {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	db := setupDatabase()
+	defer db.Close(context.Background())
+	// Get all rows from the crts SQL table
+	rows, err := db.Query(context.TODO(), "SELECT * FROM crts")
+	if err != nil {
+		http.Error(w, "Database error", http.StatusInternalServerError)
+		log.Print(err)
+		return
+	}
+	defer rows.Close()
+
+	// Convert all rows to a array of JSON objects
+	domains, err := pgx.CollectRows(rows, pgx.RowToStructByName[TLSDomain])
+	if err != nil {
+		http.Error(w, "Error reading domains", http.StatusInternalServerError)
+		log.Print(err)
+		return
+	}
+
+	// Check if there are no domains
+	if len(domains) == 0 {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	// Return the domains as JSON to the client
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(domains)
+}
+
+func deleteTLSHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "DELETE" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Check session token
+	userID, err := checkSessionToken(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	} else if userID != 1 {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	// Extract the ID from the URL path
+	// Expected format: /api/delete/:id
+	id := strings.Split(r.URL.Path, "/")[3]
+	if id == "" {
+		http.Error(w, "Missing ID", http.StatusBadRequest)
+		return
+	}
+
+	db := setupDatabase()
+	defer db.Close(context.Background())
+	c, err := db.Exec(context.TODO(), "DELETE FROM crts WHERE id = $1", id)
+	if err != nil {
+		http.Error(w, "Failed to delete domain", http.StatusInternalServerError)
+		log.Print(err)
+		return
+	}
+	// Make sure the domain was found (and deleted)
+	if c.RowsAffected() == 0 {
+		http.Error(w, "Domain not found", http.StatusNotFound)
+		return
+	}
+}
+
 func main() {
 	// Initialize the database (create tables if they don't exist)
 	InitDBSetup()
@@ -446,6 +600,9 @@ func main() {
 	mux.HandleFunc("/api/delete/", deleteHandler)
 	mux.HandleFunc("/api/refreshAll", manRefHandler)
 	mux.HandleFunc("/api/deleteClient", deleteClientHandler)
+	mux.HandleFunc("/api/tlsAddDomain", tlsAddHandler)
+	mux.HandleFunc("/api/tlsList", tlsListHandler)
+	mux.HandleFunc("/api/tlsDelete/", deleteTLSHandler)
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)

--- a/static/dash/tls/index.html
+++ b/static/dash/tls/index.html
@@ -15,7 +15,6 @@
 		</div>
 		<p>A part of <a href="../">Domain Tracker</a></p>
 	</header>
-	<h1>Not available (under construction)</h1>
 	<button id="addD">Add Website</button>
 	<button id="AddC">Add Client</button>
 	<table>
@@ -58,6 +57,6 @@
 		<h3 id="rawDataDiagHeader"></h3>
 		<pre id="rawData"></pre>
 	</dialog>
-	<!-- <script src="tls.js"></script> -->
+	<script src="tls.js"></script>
 </body>
 </html>

--- a/static/dash/tls/tls.js
+++ b/static/dash/tls/tls.js
@@ -6,8 +6,10 @@ async function loadDomains() {
 
 	let domains = await fetch("/api/tlsList")
 		.then((res) => {
-			if (res.ok) {
+			if (res.status == 200) {
 				return res.json();
+			} else if (res.status == 204) {
+				return [];
 			} else if (res.status == 401) {
 				alert("Unauthorized");
 				if (localStorage.getItem("auth")) localStorage.removeItem("auth");
@@ -19,15 +21,24 @@ async function loadDomains() {
 				return null;
 			}
 		})
-	let clients = await fetch("/api/clientList").then((res) => res.ok ? res.json() : null);
-
+		let clients = await fetch("/api/clientList")
+			.then((res) => {
+				if (res.status === 200) {
+					return res.json();
+				} else if (res.status == 204) {
+					return [];
+				} else {
+					console.error(res);
+					return null;
+				}
+			});
 	if (!domains || !clients) {
 		document.querySelector("body").innerHTML = "<h1>An error occurred and Domain tracker is unable to proceed</h1><br /><h2>Please try again later</h2><br /><p>See the browser console for more information</p>";
 		return;
 	}
 	clients.forEach((c) => {
 		let option = document.createElement("option");
-		option.value = c.id;
+		option.value = c.ID;
 		option.textContent = c.name;
 		dropdown.appendChild(option);
 	});
@@ -145,7 +156,7 @@ function main() {
 		document.getElementById("addDForm").reset();
 		fetch("/api/tlsAddDomain", {
 			method: "POST",
-			body: JSON.stringify({ domain, clientId, notes }),
+			body: JSON.stringify({ domain, clientId: parseInt(clientId), notes }),
 		}).then(async (res) => {
 			if (res.ok) {
 				alert("Domain added");

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ type Config struct {
 	InitUsr       string `json:"initUser"`
 	ListenAddr    string `json:"listenAddr"`
 	DaysDomainExp int    `json:"remindDomainExpDays"`
+	DaysCertExp   int    `json:"remindCertExpDays"`
 	EmailForExp   string `json:"to_email"`
 	FromEmail     string `json:"from_email"`
 	SMTPHost      string `json:"smtp_host"`

--- a/types.go
+++ b/types.go
@@ -101,3 +101,14 @@ type NSChange struct {
 	NewNS     []string  `json:"newNS"`
 	CheckedAt time.Time `json:"checkedAt"`
 }
+
+type TLSDomain struct {
+	ID         int       `db:"id" json:"id"`
+	Domain     string    `db:"domain" json:"domain"`
+	CommonName string    `db:"commonname" json:"commonName"`
+	Expiration time.Time `db:"expiration" json:"expiration"`
+	Authority  string    `db:"authority" json:"authority,omitempty"`
+	ClientID   int       `db:"clientid" json:"clientID"`
+	RawData    string    `db:"rawdata" json:"rawData"`
+	Notes      *string   `db:"notes" json:"notes,omitempty"`
+}


### PR DESCRIPTION
While TLS tracker is a part of Domain tracker, it is not covered by the standard quality guidelines. This PR re-adding the needed the endpoints for TLS tracker in the main Go binary and re-enables the frontend for TLS tracker. It also adds email reminders for certs that are sent along-side domain exp emails. 